### PR TITLE
Fix Debian based repositories

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,8 +17,8 @@ class bareos::params {
   ### Application related parameters
 
   $repo_distro = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/                          => 'Debian_7.0',
-    /(?i:Ubuntu)/                                      => 'xUbuntu_12.04',
+    /(?i:Debian)/                                      => "Debian_${::lsbdistrelease}",
+    /(?i:Ubuntu|Mint)/                                 => "xUbuntu_${::lsbdistrelease}",
     /(?i:redhat|centos|scientific|oraclelinux|fedora)/ => "${::operatingsystem}_${::operatingsystemmajrelease}",
     default                                            => 'UNKNOWN',
   }


### PR DESCRIPTION
One of my agents runs on Ubuntu 12.04 and using the Debian repository breaks Bareos installation. 
