### PR TITLE
manage repo and uid

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,8 @@ class bareos (
   $manage_director         = params_lookup( 'manage_director' ),
   $manage_console          = params_lookup( 'manage_console' ),
   $manage_database         = params_lookup( 'manage_database' ),
+  $manage_repository       = params_lookup( 'manage_repository'),
+  $manage_uid              = params_lookup( 'uid'),
   $database_backend        = params_lookup( 'database_backend' ),
   $database_host           = params_lookup( 'database_host' ),
   $database_port           = params_lookup( 'database_port' ),
@@ -129,6 +131,8 @@ class bareos (
   $bool_manage_director=any2bool($manage_director)
   $bool_manage_console=any2bool($manage_console)
   $bool_manage_database=any2bool($manage_database)
+  $bool_manage_repository=any2bool($manage_repository)
+  $bool_manage_uid=any2bool($manage_uid)
 
   ### Definition of some variables used in the module
 
@@ -206,12 +210,15 @@ class bareos (
 
   ### Resources common to all components
 
-  group { $bareos::process_group:
-    ensure => present,
-  } ->
-  user { $bareos::process_user:
-    ensure => present,
-    gid    => 'bareos',
+
+  if ($bool_manage_uid){
+	  group { $bareos::process_group:
+	    ensure => present,
+	  } ->
+	  user { $bareos::process_user:
+	    ensure => present,
+	    gid    => 'bareos',
+	  }
   }
 
   file { $bareos::working_directory:
@@ -225,6 +232,7 @@ class bareos (
       ensure  => link,
       target  => $bareos::working_directory,
       require => File[$bareos::working_directory],
+      force   => true,
     }
   }
 

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -16,30 +16,32 @@
 #
 class bareos::repository inherits bareos {
 
-  case $::operatingsystem {
+  if ($bool_manage_repository){
+	  case $::operatingsystem {
 
-    redhat,centos,fedora,Scientific,OracleLinux: {
-      file { 'bareos.repo':
-        path    => '/etc/yum.repos.d/bareos.repo',
-        content => template('bareos/bareos.repo.erb'),
-      }
-    }
+	    redhat,centos,fedora,Scientific,OracleLinux: {
+	      file { 'bareos.repo':
+	        path    => '/etc/yum.repos.d/bareos.repo',
+	        content => template('bareos/bareos.repo.erb'),
+	      }
+	    }
 
-    Debian,Ubuntu: {
-      file { '/etc/apt/sources.list.d/bareos.list':
-        content => "deb http://download.bareos.org/bareos/release/${bareos::repo_flavour}/${bareos::repo_distro} /\n"
-      }
-      ~>
-      exec { 'bareos-key':
-        command     => "/usr/bin/wget -q http://download.bareos.org/bareos/release/${bareos::repo_flavour}/${bareos::repo_distro}/Release.key -O- | /usr/bin/apt-key add -",
-        refreshonly => true
-      }
-      ~>
-      exec { 'update-apt':
-        command     => '/usr/bin/apt-get update',
-        refreshonly => true
-      }
-    }
-    default: { fail("${::hostname}: This module does not support operatingsystem ${::operatingsystem}") }
-  }
+	    Debian,Ubuntu: {
+	      file { '/etc/apt/sources.list.d/bareos.list':
+	        content => "deb http://download.bareos.org/bareos/release/${bareos::repo_flavour}/${bareos::repo_distro} /\n"
+	      }
+	      ~>
+	      exec { 'bareos-key':
+	        command     => "/usr/bin/wget -q http://download.bareos.org/bareos/release/${bareos::repo_flavour}/${bareos::repo_distro}/Release.key -O- | /usr/bin/apt-key add -",
+	        refreshonly => true
+	      }
+	      ~>
+	      exec { 'update-apt':
+	        command     => '/usr/bin/apt-get update',
+	        refreshonly => true
+	      }
+	    }
+	    default: { fail("${::hostname}: This module does not support operatingsystem ${::operatingsystem}") }
+	  }
+	}
 }


### PR DESCRIPTION
Give the option to manage the repository: Needed when you use your own repo server.
Give the option to manage the uid: Needed when you use a static uid accross all servers for a user.