### PR TITLE
add some options to bareos::director::messages

### DIFF
--- a/manifests/director/messages.pp
+++ b/manifests/director/messages.pp
@@ -2,11 +2,29 @@
 #
 # Used to create messages resources
 #
+# Valid parameters are:
+#
+# $mail_command     - path to the smtp command used to send email
+# $mail_from        - email address used in the from: field
+# $mail_to          - email address used in the to: field
+# $mail_host        - smtp server used to send the email
+# $mail_type        - message type to send by email
+# $mailonerror_type - message type sent on job error
+# $console          - message type sent to the bareos console
+# $catalog          - message type sent to the catalog database
+# $append           - Append messages to a log file
+# $options_hash     - Extra configuration values
+#
 define bareos::director::messages (
   $mail_command = '',
-  $mail_host = 'localhost',
   $mail_from = '',
   $mail_to = '',
+  $mail_host = 'localhost',
+  $mail_type = 'all, !skipped',
+  $mailonerror_type = 'all',
+  $console = 'all, !skipped, !saved',
+  $catalog = 'all, !skipped, !saved',
+  $append = "\"${bareos::log_file}\" = all, !skipped",
   $options_hash = {},
   $template = 'bareos/director/messages.conf.erb'
 ) {
@@ -24,6 +42,14 @@ define bareos::director::messages (
       default => [$mail_to],
     },
     default   => $mail_to,
+  }
+
+  $array_append = is_array($append) ? {
+    false     => $append ? {
+      ''      => [],
+      default => [$append],
+    },
+    default   => $append,
   }
 
   $manage_messages_file_content = $template ? {
@@ -45,4 +71,3 @@ define bareos::director::messages (
   }
 
 }
-

--- a/manifests/director/messages.pp
+++ b/manifests/director/messages.pp
@@ -12,7 +12,7 @@
 # $mailonerror_type - message type sent on job error
 # $console          - message type sent to the bareos console
 # $catalog          - message type sent to the catalog database
-# $append           - Append messages to a log file
+# $append_type      - message type sent to the log file
 # $options_hash     - Extra configuration values
 #
 define bareos::director::messages (
@@ -24,7 +24,7 @@ define bareos::director::messages (
   $mailonerror_type = 'all',
   $console = 'all, !skipped, !saved',
   $catalog = 'all, !skipped, !saved',
-  $append = "\"${bareos::log_file}\" = all, !skipped",
+  $append_type = 'all, !skipped',
   $options_hash = {},
   $template = 'bareos/director/messages.conf.erb'
 ) {
@@ -42,14 +42,6 @@ define bareos::director::messages (
       default => [$mail_to],
     },
     default   => $mail_to,
-  }
-
-  $array_append = is_array($append) ? {
-    false     => $append ? {
-      ''      => [],
-      default => [$append],
-    },
-    default   => $append,
   }
 
   $manage_messages_file_content = $template ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class bareos (
   $database_user           = params_lookup( 'database_user' ),
   $database_password       = params_lookup( 'database_password' ),
   $heartbeat_interval      = params_lookup( 'heartbeat_interval'),
+  $auditing                = params_lookup( 'auditing'),
   $password_salt           = params_lookup( 'password_salt' ),
   $default_password        = params_lookup( 'default_password' ),
   $default_file_retention  = params_lookup( 'default_file_retention' ),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,6 +44,7 @@ class bareos::params {
   }
 
   $heartbeat_interval = '1 minute'
+  $auditing           = 'no'
   $working_directory  = $::operatingsystem ? {
     default => '/var/lib/bareos'
   }

--- a/spec/classes/bareos_director_spec.rb
+++ b/spec/classes/bareos_director_spec.rb
@@ -76,6 +76,7 @@ Director {
   Messages = "standard"
   DirAddress = 10.42.42.42
   HeartbeatInterval = 1 minute
+  Auditing = no
 }
 
 # Restricted Console, used by tray-monitor for Director status.

--- a/templates/bareos-dir.conf.erb
+++ b/templates/bareos-dir.conf.erb
@@ -11,6 +11,7 @@ Director {
   Messages = "<%= scope.lookupvar('bareos::default_messages') %>"
   DirAddress = <%= scope.lookupvar('bareos::director_address') %>
   HeartbeatInterval = <%= scope.lookupvar('bareos::heartbeat_interval') %>
+  Auditing = <%= scope.lookupvar('bareos::auditing') %>
 }
 
 # Restricted Console, used by tray-monitor for Director status.

--- a/templates/director/messages.conf.erb
+++ b/templates/director/messages.conf.erb
@@ -8,11 +8,20 @@ Messages {
       @array_mail_to != [] -%>
   mailcommand = "<%= @mail_command %> -h <%= @mail_host %> -f \"Bareos <<%= @mail_from %>>\" -s \"Bareos: %t %e of %c %l\" %r"
   operatorcommand = "<%= @mail_command %> -h <%= @mail_host %> -f \"Bareos <<%= @mail_from %>>\" -s \"Bareos: Intervention needed for %j\" %r"
-  mail = <%= @array_mail_to * ',' %> = all, !skipped
+  mail = <%= @array_mail_to * ',' %> = <%= @mail_type %>
   operator = <%= @array_mail_to * ',' %> = mount
-  mailonerror = <%= @array_mail_to * ',' %> = all
+  mailonerror = <%= @array_mail_to * ',' %> = <%= @mailonerror_type %>
 <% end -%>
-  console = all, !skipped, !saved
-  catalog = all, !skipped, !saved
-  append = "<%= scope.lookupvar('bareos::log_file') %>" = all, !skipped
+  console = <%= @console %>
+  catalog = <%= @catalog %>
+<% if @array_append != [] -%>
+<% @array_append.each do |append| -%>
+  append = <%= append %>
+<% end -%>
+<% end -%>
+<% if @options_hash != {} -%>
+<% @options_hash.each do |key,value| -%>
+  <%= key %> = <%= value %>
+<% end -%>
+<% end -%>
 }

--- a/templates/director/messages.conf.erb
+++ b/templates/director/messages.conf.erb
@@ -14,11 +14,7 @@ Messages {
 <% end -%>
   console = <%= @console %>
   catalog = <%= @catalog %>
-<% if @array_append != [] -%>
-<% @array_append.each do |append| -%>
-  append = <%= append %>
-<% end -%>
-<% end -%>
+  append = "<%= scope.lookupvar('bareos::log_file') %>" = <%= append_type %>
 <% if @options_hash != {} -%>
 <% @options_hash.each do |key,value| -%>
   <%= key %> = <%= value %>


### PR DESCRIPTION
To create multiple Messages configurations where one can filter out message types. 

```
Messages {
  Name = Standard
  mailcommand = "/usr/bin/bsmtp -h localhost -f \"\(Bareos\) \<%r\>\" -s \"Bareos: %t %e of %c %l\" %r"
  operatorcommand = "/usr/bin/bsmtp -h localhost -f \"\(Bareos\) \<%r\>\" -s \"Bareos: Intervention needed for %j\" %r"
  mail = root@localhost = all, !skipped, !audit # (#02)
  operator = root@localhost = mount     # (#03)
  console = all, !skipped, !saved, !audit
  catalog = all, !audit
  append = "/var/log/bareos/bareos.log" = all, !skipped, !audit
  append = "/var/log/bareos/bareos-audit.log" = audit
}
```
