### PR TITLE
Fix repository on Ubuntu

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -19,14 +19,14 @@ class bareos::repository inherits bareos {
   if ($bool_manage_repository){
       case $::operatingsystem {
 
-        redhat,centos,fedora,Scientific,OracleLinux: {
+        /(?i:redhat|centos|fedora|scientific|oraclelinux)/: {
           file { 'bareos.repo':
             path    => '/etc/yum.repos.d/bareos.repo',
             content => template('bareos/bareos.repo.erb'),
           }
         }
 
-        Debian,Ubuntu: {
+        /(?i:debian|ubuntu)/: {
           file { '/etc/apt/sources.list.d/bareos.list':
             content => "deb http://download.bareos.org/bareos/release/${bareos::repo_flavour}/${bareos::repo_distro} /\n"
           }


### PR DESCRIPTION
the case only works for 'ubuntu', not 'Ubuntu', so let's be case insensitive